### PR TITLE
feat: unify BLE-scanner suite & harden env bootstrap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core dependencies
 Flask==2.2.2
+Werkzeug<3
 bleak==0.20.2
 python-dotenv==1.0.0
 requests==2.31.0


### PR DESCRIPTION
## Summary
- pin Werkzeug<3 to avoid Flask import errors

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'url_quote' from 'werkzeug.urls')*
- `pip install -r requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e33d9338c832b97dae297fa117000

## Summary by Sourcery

Bug Fixes:
- Pin Werkzeug<3 in requirements.txt to avoid ImportError for url_quote in Flask