### PR TITLE
Add Shodan/WiGLE integration and concurrent scanning

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Request, Form
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 import config
+from external_api import shodan_lookup, wigle_lookup
 
 router = APIRouter()
 templates = Jinja2Templates(directory="web/templates")
@@ -33,3 +34,13 @@ async def set_config(
     config.TELEGRAM_BOT_TOKEN = telegram_token
     config.TELEGRAM_CHAT_ID = telegram_chat
     return RedirectResponse(url="/config", status_code=303)
+
+
+@router.get("/shodan")
+async def shodan(query: str):
+    return JSONResponse(shodan_lookup(query))
+
+
+@router.get("/wigle")
+async def wigle(ssid: str):
+    return JSONResponse(wigle_lookup(ssid))

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,6 +5,7 @@ from core.scanner import EVENT_BUS, run_scanner
 from plugins import load_plugins
 from mqtt_client import setup as mqtt_setup
 from core.utils import setup_logging
+from external_api import shodan_lookup, wigle_lookup
 
 app = typer.Typer(help="BLE Scanner Suite CLI")
 
@@ -13,12 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 @app.command()
-def scan(interval: int = 5):
+def scan(interval: int = 5, workers: int = 1):
     """Run BLE scanner."""
     load_plugins()
     mqtt_setup()
     try:
-        asyncio.run(run_scanner(interval))
+        asyncio.run(run_scanner(interval, workers))
     except KeyboardInterrupt:
         logger.info("Scanner stopped by user")
 
@@ -33,6 +34,20 @@ def listen():
             logger.info("%s", event)
 
     asyncio.run(_listen())
+
+
+@app.command()
+def shodan(query: str):
+    """Query Shodan."""
+    res = shodan_lookup(query)
+    typer.echo(res)
+
+
+@app.command()
+def wigle(ssid: str):
+    """Query Wigle for a Wi-Fi SSID."""
+    res = wigle_lookup(ssid)
+    typer.echo(res)
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -34,3 +34,8 @@ WHATSAPP_API_URL = os.getenv("WHATSAPP_API_URL", "")
 WHATSAPP_AUTH_TOKEN = os.getenv("WHATSAPP_AUTH_TOKEN", "")
 WHATSAPP_FROM = os.getenv("WHATSAPP_FROM", "")
 WHATSAPP_TO = os.getenv("WHATSAPP_TO", "")
+
+# External API configuration
+SHODAN_API_KEY = os.getenv("SHODAN_API_KEY", "")
+WIGLE_API_NAME = os.getenv("WIGLE_API_NAME", "")
+WIGLE_API_TOKEN = os.getenv("WIGLE_API_TOKEN", "")

--- a/external_api.py
+++ b/external_api.py
@@ -1,0 +1,47 @@
+import os
+import logging
+from typing import Any, Dict
+import requests
+
+logger = logging.getLogger(__name__)
+
+SHODAN_API_KEY = os.getenv("SHODAN_API_KEY", "")
+WIGLE_API_NAME = os.getenv("WIGLE_API_NAME", "")
+WIGLE_API_TOKEN = os.getenv("WIGLE_API_TOKEN", "")
+
+
+def shodan_lookup(query: str) -> Dict[str, Any]:
+    """Query the Shodan API for a host or search string."""
+    if not SHODAN_API_KEY:
+        logger.warning("Shodan API key not configured")
+        return {}
+    url = "https://api.shodan.io/shodan/host/search"
+    params = {"key": SHODAN_API_KEY, "query": query}
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Shodan lookup failed: %s", exc)
+        return {}
+
+
+def wigle_lookup(ssid: str) -> Dict[str, Any]:
+    """Search Wigle for a Wi-Fi SSID."""
+    if not (WIGLE_API_NAME and WIGLE_API_TOKEN):
+        logger.warning("Wigle credentials not configured")
+        return {}
+    url = "https://api.wigle.net/api/v2/network/search"
+    params = {"ssid": ssid}
+    try:
+        resp = requests.get(
+            url,
+            params=params,
+            auth=(WIGLE_API_NAME, WIGLE_API_TOKEN),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Wigle lookup failed: %s", exc)
+        return {}

--- a/qt_frontend/main_window.py
+++ b/qt_frontend/main_window.py
@@ -2,6 +2,7 @@ from PyQt6 import QtWidgets
 from core.scanner import EVENT_BUS
 import asyncio
 import logging
+from external_api import shodan_lookup, wigle_lookup
 
 logger = logging.getLogger(__name__)
 
@@ -12,12 +13,34 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("BLE Scanner")
         self.text = QtWidgets.QTextEdit()
         self.setCentralWidget(self.text)
+        self._setup_menu()
         asyncio.create_task(self.update_loop())
+
+    def _setup_menu(self) -> None:
+        menu = self.menuBar().addMenu("Tools")
+        shodan_action = menu.addAction("Shodan Lookup")
+        shodan_action.triggered.connect(
+            lambda: asyncio.create_task(self.lookup_shodan())
+        )
+        wigle_action = menu.addAction("Wigle Lookup")
+        wigle_action.triggered.connect(lambda: asyncio.create_task(self.lookup_wigle()))
 
     async def update_loop(self):
         while True:
             event = await EVENT_BUS.get()
             self.text.append(str(event))
+
+    async def lookup_shodan(self) -> None:
+        query, ok = QtWidgets.QInputDialog.getText(self, "Shodan Query", "Query:")
+        if ok:
+            res = await asyncio.to_thread(shodan_lookup, query)
+            self.text.append(str(res))
+
+    async def lookup_wigle(self) -> None:
+        ssid, ok = QtWidgets.QInputDialog.getText(self, "WiGLE SSID", "SSID:")
+        if ok:
+            res = await asyncio.to_thread(wigle_lookup, ssid)
+            self.text.append(str(res))
 
 
 def run():

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+import external_api
+from core import scanner
+
+
+def test_vendor_for_mac_cache():
+    scanner.VENDOR_CACHE.clear()
+    scanner.VENDOR_CACHE["AA11BB"] = "TestVendor"
+    assert scanner.vendor_for_mac("AA:11:BB:00:00:00") == "TestVendor"
+
+
+@patch("external_api.requests.get")
+def test_shodan_lookup(mock_get):
+    mock_get.return_value.json.return_value = {"matches": []}
+    mock_get.return_value.raise_for_status.return_value = None
+    external_api.SHODAN_API_KEY = "dummy"
+    res = external_api.shodan_lookup("test")
+    assert "matches" in res


### PR DESCRIPTION
## Summary
- integrate external Shodan and WiGLE lookups
- support vendor lookup via `mac-vendor-lookup`
- allow concurrent scanner workers
- add hotkey shutdown to sniffing script
- expose API and CLI commands for lookups
- show lookup tools in the Qt GUI
- add tests for external API helpers

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4304b8c8832b866e7d19ec0bc65e