### PR TITLE
Implement aggregator and plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,14 @@ A modern Bluetooth Low Energy (BLE) scanner that monitors nearby devices and pro
   - Telegram bot notifications
   - WhatsApp message alerts
 - 🔌 Runtime plugin system for custom analyzers/exporters
+- 📥 CLI command to install community plugins via apt/brew
 - 📡 MQTT broadcasting alongside WebSocket updates
 - 🐳 Headless container mode for lightweight deployments
 - 🛠️ Web-based configuration page
 - 📝 Rotating log files with archival
 - 🧩 Vendor prefix lookup for device manufacturers
 - ⚡ Concurrent scanning workers via asyncio
+- 🗂️ Centralized result dashboard with /export API
 - 🕹️ `sniff_my_ble.py` script with hotkey shutdown
 
 ## Requirements

--- a/api/routes.py
+++ b/api/routes.py
@@ -3,6 +3,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 import config
 from external_api import shodan_lookup, wigle_lookup
+from core.db import get_devices
 
 router = APIRouter()
 templates = Jinja2Templates(directory="web/templates")
@@ -44,3 +45,8 @@ async def shodan(query: str):
 @router.get("/wigle")
 async def wigle(ssid: str):
     return JSONResponse(wigle_lookup(ssid))
+
+
+@router.get("/export")
+async def export(limit: int = 100):
+    return JSONResponse(get_devices(limit))

--- a/cli/main.py
+++ b/cli/main.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import typer
 from core.scanner import EVENT_BUS, run_scanner
-from plugins import load_plugins
+from plugins import load_plugins, install_plugin
 from mqtt_client import setup as mqtt_setup
 from core.utils import setup_logging
 from external_api import shodan_lookup, wigle_lookup
@@ -48,6 +48,16 @@ def wigle(ssid: str):
     """Query Wigle for a Wi-Fi SSID."""
     res = wigle_lookup(ssid)
     typer.echo(res)
+
+
+@app.command()
+def plugin_install(package: str, manager: str = "apt"):
+    """Install a system plugin via apt or brew."""
+    success = install_plugin(package, manager)
+    if success:
+        typer.echo("Installed successfully")
+    else:
+        typer.echo("Installation failed")
 
 
 if __name__ == "__main__":

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["scanner", "db", "aggregator"]

--- a/core/aggregator.py
+++ b/core/aggregator.py
@@ -1,0 +1,32 @@
+import logging
+from typing import Iterable, List, Dict
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_results(url: str) -> List[Dict[str, str]]:
+    """Fetch device results from a remote dashboard."""
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, list):
+            return data
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Failed to fetch %s: %s", url, exc)
+    return []
+
+
+def aggregate(endpoints: Iterable[str]) -> List[Dict[str, str]]:
+    """Aggregate device lists from multiple endpoints."""
+    merged: Dict[str, Dict[str, str]] = {}
+    for ep in endpoints:
+        for dev in fetch_results(ep):
+            mac = dev.get("mac_address")
+            if not mac:
+                continue
+            curr = merged.get(mac)
+            if not curr or curr.get("last_seen", "") < dev.get("last_seen", ""):
+                merged[mac] = dev
+    return list(merged.values())

--- a/core/db.py
+++ b/core/db.py
@@ -30,3 +30,19 @@ def purge_old_entries(days: int = 30) -> None:
     cursor.execute("DELETE FROM Devices WHERE last_seen < ?", (cutoff,))
     conn.commit()
     conn.close()
+
+
+def get_devices(limit: int | None = None):
+    """Return devices as list of dicts."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    query = "SELECT * FROM Devices ORDER BY last_seen DESC"
+    if limit:
+        query += " LIMIT ?"
+        cursor.execute(query, (limit,))
+    else:
+        cursor.execute(query)
+    rows = cursor.fetchall()
+    conn.close()
+    return [dict(r) for r in rows]

--- a/external_api.py
+++ b/external_api.py
@@ -8,6 +8,8 @@ logger = logging.getLogger(__name__)
 SHODAN_API_KEY = os.getenv("SHODAN_API_KEY", "")
 WIGLE_API_NAME = os.getenv("WIGLE_API_NAME", "")
 WIGLE_API_TOKEN = os.getenv("WIGLE_API_TOKEN", "")
+CENSYS_API_ID = os.getenv("CENSYS_API_ID", "")
+CENSYS_API_SECRET = os.getenv("CENSYS_API_SECRET", "")
 
 
 def shodan_lookup(query: str) -> Dict[str, Any]:
@@ -44,4 +46,25 @@ def wigle_lookup(ssid: str) -> Dict[str, Any]:
         return resp.json()
     except Exception as exc:  # pragma: no cover - network errors
         logger.error("Wigle lookup failed: %s", exc)
+        return {}
+
+
+def censys_lookup(query: str) -> Dict[str, Any]:
+    """Query the Censys search API."""
+    if not (CENSYS_API_ID and CENSYS_API_SECRET):
+        logger.warning("Censys credentials not configured")
+        return {}
+    url = "https://search.censys.io/api/v2/hosts/search"
+    params = {"q": query}
+    try:
+        resp = requests.get(
+            url,
+            params=params,
+            auth=(CENSYS_API_ID, CENSYS_API_SECRET),
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Censys lookup failed: %s", exc)
         return {}

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+from core import aggregator
+
+
+def test_aggregate_deduplication():
+    with patch("core.aggregator.fetch_results") as mock_fetch:
+        mock_fetch.side_effect = [
+            [{"mac_address": "AA", "last_seen": "1"}],
+            [{"mac_address": "AA", "last_seen": "2"}],
+        ]
+        res = aggregator.aggregate(["url1", "url2"])
+        assert res[0]["last_seen"] == "2"

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -16,3 +16,13 @@ def test_shodan_lookup(mock_get):
     external_api.SHODAN_API_KEY = "dummy"
     res = external_api.shodan_lookup("test")
     assert "matches" in res
+
+
+@patch("external_api.requests.get")
+def test_censys_lookup(mock_get):
+    mock_get.return_value.json.return_value = {"result": []}
+    mock_get.return_value.raise_for_status.return_value = None
+    external_api.CENSYS_API_ID = "id"
+    external_api.CENSYS_API_SECRET = "secret"
+    res = external_api.censys_lookup("1.2.3.4")
+    assert "result" in res


### PR DESCRIPTION
## Summary
- add aggregator module for centralized dashboards
- expose `/export` route returning device data
- support installing system plugins via CLI
- add Censys lookup in `external_api`
- document new features in README
- tests for aggregator and Censys

## Testing
- `ruff check .`
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e45138ae8832b9f5080befe162703