### PR TITLE
Add aggregator CLI command

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,11 +1,15 @@
 import asyncio
+import json
 import logging
+from typing import List
+
 import typer
 from core.scanner import EVENT_BUS, run_scanner
 from plugins import load_plugins, install_plugin
 from mqtt_client import setup as mqtt_setup
 from core.utils import setup_logging
 from external_api import shodan_lookup, wigle_lookup
+from core import aggregator
 
 app = typer.Typer(help="BLE Scanner Suite CLI")
 
@@ -58,6 +62,18 @@ def plugin_install(package: str, manager: str = "apt"):
         typer.echo("Installed successfully")
     else:
         typer.echo("Installation failed")
+
+
+@app.command()
+def aggregate(
+    endpoints: List[str] = typer.Option([], "--endpoint", help="Remote dashboard URLs")
+):
+    """Aggregate device results from remote dashboards."""
+    if not endpoints:
+        typer.echo("No endpoints provided", err=True)
+        raise typer.Exit(code=1)
+    results = aggregator.aggregate(endpoints)
+    typer.echo(json.dumps(results, indent=2))
 
 
 if __name__ == "__main__":

--- a/proposals.md
+++ b/proposals.md
@@ -7,3 +7,6 @@ The following ideas could further improve the BLE Scanner Suite:
 - **Distributed aggregation** – combine results from multiple scanners into one dashboard.
 - **Docker packaging** – provide an official container image for simplified deployment.
 - **Plugin marketplace** – allow community plugins to be discovered and installed via the CLI.
+- **Aggregator CLI** – fetch and merge device lists from remote dashboards.
+- **Graph relationships** – visualise interactions between nearby devices.
+- **Encrypted MQTT support** – secure message transport with TLS.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+from typer.testing import CliRunner
+from unittest.mock import patch
+
+from cli.main import app
+
+
+def test_aggregate_command():
+    runner = CliRunner()
+    with patch("cli.main.aggregator.aggregate") as mock_agg:
+        mock_agg.return_value = [{"mac_address": "AA"}]
+        result = runner.invoke(
+            app, ["aggregate", "--endpoint", "url1", "--endpoint", "url2"]
+        )
+        assert result.exit_code == 0
+        assert "AA" in result.output
+        mock_agg.assert_called_once_with(["url1", "url2"])


### PR DESCRIPTION
## Summary
- enhance CLI with `aggregate` command for merging results from remote dashboards
- test the new command with `typer.testing.CliRunner`
- document extra feature ideas in `proposals.md`

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4ab56920832bac6e6198f32a35a7

## Summary by Sourcery

Introduce an `aggregate` command in the CLI to retrieve and merge device lists from specified remote dashboard endpoints, include a corresponding unit test, and update feature proposals accordingly.

New Features:
- Add `aggregate` CLI command to fetch and merge device results from remote dashboards

Documentation:
- Document the aggregator CLI feature in `proposals.md`

Tests:
- Add unit test for `aggregate` command using Typer’s CliRunner and a mocked aggregator