### PR TITLE
Integrate features and add exporter

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from pathlib import Path
 from typing import List
 
 import typer
@@ -10,6 +11,7 @@ from mqtt_client import setup as mqtt_setup
 from core.utils import setup_logging
 from external_api import shodan_lookup, wigle_lookup
 from core import aggregator
+from core.exporter import export_data
 
 app = typer.Typer(help="BLE Scanner Suite CLI")
 
@@ -74,6 +76,20 @@ def aggregate(
         raise typer.Exit(code=1)
     results = aggregator.aggregate(endpoints)
     typer.echo(json.dumps(results, indent=2))
+
+
+@app.command()
+def export(
+    fmt: str = typer.Option("json", "--format", "-f", help="json, csv, sqlite"),
+    output: Path = typer.Argument(Path("export.out")),
+    limit: int = 100,
+):
+    """Export the local database."""
+    from core.db import init_db
+
+    init_db()
+    export_data(fmt, output, limit)
+    typer.echo(f"Exported to {output}")
 
 
 if __name__ == "__main__":

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["scanner", "db", "aggregator"]
+__all__ = ["scanner", "db", "aggregator", "exporter"]

--- a/core/exporter.py
+++ b/core/exporter.py
@@ -1,0 +1,36 @@
+import json
+import csv
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from core.db import get_devices
+from config import DB_PATH
+
+
+def export_data(fmt: str, dest: Path, limit: Optional[int] = None) -> Path:
+    """Export device records to JSON, CSV or SQLite."""
+    fmt = fmt.lower()
+    data = get_devices(limit)
+    if fmt == "json":
+        dest.write_text(json.dumps(data, indent=2))
+    elif fmt == "csv":
+        headers = [
+            "mac_address",
+            "device_name",
+            "first_seen",
+            "last_seen",
+            "frequency_count",
+            "rssi",
+            "manufacturer",
+            "rssi_history",
+        ]
+        with dest.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=headers)
+            writer.writeheader()
+            writer.writerows(data)
+    elif fmt == "sqlite":
+        shutil.copy(Path(DB_PATH), dest)
+    else:
+        raise ValueError(f"Unsupported format {fmt}")
+    return dest

--- a/tests/test_ble_scanner.py
+++ b/tests/test_ble_scanner.py
@@ -1,5 +1,5 @@
 import asyncio
-from core.scanner import EVENT_BUS, parse_ibeacon
+from core.scanner import EVENT_BUS, parse_ibeacon, parse_eddystone
 
 
 def test_event_bus():
@@ -16,3 +16,9 @@ def test_parse_ibeacon():
     res = parse_ibeacon(payload)
     assert res["major"] == 0
     assert res["minor"] == 0
+
+
+def test_parse_eddystone():
+    payload = bytes([0x00, 0xC5]) + b"\x01" * 16
+    res = parse_eddystone(payload)
+    assert res["type"] == "uid"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,11 @@ def test_aggregate_command():
         assert result.exit_code == 0
         assert "AA" in result.output
         mock_agg.assert_called_once_with(["url1", "url2"])
+
+
+def test_export_command(tmp_path):
+    runner = CliRunner()
+    out = tmp_path / "data.json"
+    result = runner.invoke(app, ["export", "--format", "json", str(out), "--limit", "0"])
+    assert result.exit_code == 0
+    assert out.exists()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from core.db import init_db
+from core.exporter import export_data
+
+
+def test_export_json(tmp_path):
+    init_db()
+    path = tmp_path / "out.json"
+    res = export_data("json", path, limit=0)
+    assert path.exists()
+    assert res == path
+
+
+def test_export_csv(tmp_path):
+    init_db()
+    path = tmp_path / "out.csv"
+    res = export_data("csv", path, limit=0)
+    assert path.exists()
+    text = path.read_text()
+    assert "mac_address" in text
+
+
+def test_export_sqlite(tmp_path):
+    init_db()
+    path = tmp_path / "out.sqlite"
+    res = export_data("sqlite", path)
+    assert path.exists()
+    assert path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- hook notifications into broadcast_event
- parse Eddystone frames during scans
- add exporter utility with CLI command
- extend tests for exporter and new parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e51985be0832ba668a30fbd0608bd

## Summary by Sourcery

Integrate notification dispatch in the BLE event pipeline, extend the scanner to parse Eddystone frames, and introduce an exporter utility with a CLI command, including corresponding tests.

New Features:
- Send notifications for new BLE devices in broadcast_event
- Parse Eddystone UID and URL frames during BLE scans
- Add a CLI export command with JSON, CSV, and SQLite output formats

Tests:
- Add unit tests for Eddystone parsing
- Add tests for the exporter utility and export CLI command