### PR TITLE
Add HID replay module and CLI integration

### DIFF
--- a/active/__init__.py
+++ b/active/__init__.py
@@ -1,0 +1,2 @@
+"""Active attack modules."""
+

--- a/active/hid_replay.py
+++ b/active/hid_replay.py
@@ -1,0 +1,32 @@
+"""Replay HID notifications to a BLE device."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from bleak import BleakClient
+
+logger = logging.getLogger(__name__)
+
+
+async def _replay_sequence(client: BleakClient, char_uuid: str, packets: Iterable[bytes]) -> None:
+    """Write each packet to the characteristic with a short delay."""
+    for pkt in packets:
+        logger.debug("Writing %s", pkt.hex())
+        await client.write_gatt_char(char_uuid, pkt)
+        await asyncio.sleep(0.05)
+
+
+async def replay(address: str, char_uuid: str, packet_file: Path) -> None:
+    """Connect to *address* and replay HID packets from *packet_file*."""
+    logger.info("Connecting to %s", address)
+    async with BleakClient(address) as client:
+        data = json.loads(packet_file.read_text())
+        packets = [bytes.fromhex(p) for p in data]
+        await _replay_sequence(client, char_uuid, packets)
+    logger.info("Replay complete")
+

--- a/cli/main.py
+++ b/cli/main.py
@@ -6,6 +6,7 @@ from typing import List
 
 import typer
 
+from active.hid_replay import replay as hid_replay
 from core import aggregator
 from core.exporter import export_data
 from core.scanner import EVENT_BUS, run_scanner
@@ -42,7 +43,7 @@ def scan(
                 processes,
                 stop_event=stop_event,
                 threaded_scan=threaded_scan,
-            )
+            ),
         )
         try:
             await task
@@ -93,7 +94,7 @@ def plugin_install(package: str, manager: str = "apt"):
 
 @app.command()
 def aggregate(
-    endpoints: List[str] = typer.Option([], "--endpoint", help="Remote dashboard URLs")
+    endpoints: List[str] = typer.Option([], "--endpoint", help="Remote dashboard URLs"),
 ):
     """Aggregate device results from remote dashboards."""
     if not endpoints:
@@ -115,6 +116,16 @@ def export(
     init_db()
     export_data(fmt, output, limit)
     typer.echo(f"Exported to {output}")
+
+
+@app.command()
+def hid_replay(address: str, char_uuid: str, packet_file: Path):
+    """Replay HID notifications from PACKET_FILE."""
+
+    async def _run() -> None:
+        await hid_replay(address, char_uuid, packet_file)
+
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":

--- a/proposals.md
+++ b/proposals.md
@@ -10,3 +10,5 @@ The following ideas could further improve the BLE Scanner Suite:
 - **Aggregator CLI** – fetch and merge device lists from remote dashboards.
 - **Graph relationships** – visualise interactions between nearby devices.
 - **Encrypted MQTT support** – secure message transport with TLS.
+- **HID injection support** – replay captured keystrokes over BLE using the new active toolkit.
+- **Protocol radar graphs** – visualise protocol usage in real time within the dashboard.

--- a/tests/test_hid_replay.py
+++ b/tests/test_hid_replay.py
@@ -1,0 +1,37 @@
+import asyncio
+import json
+from pathlib import Path
+
+from active import hid_replay
+
+
+class DummyClient:
+    def __init__(self, address: str) -> None:
+        self.address = address
+        self.writes: list[tuple[str, bytes]] = []
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        pass
+
+    async def write_gatt_char(self, uuid: str, data: bytes) -> None:
+        self.writes.append((uuid, data))
+
+
+def test_replay(tmp_path: Path, monkeypatch) -> None:
+    packets = ["01ff", "02aa"]
+    pfile = tmp_path / "pkts.json"
+    pfile.write_text(json.dumps(packets))
+
+    dummy = DummyClient("AA:BB")
+
+    monkeypatch.setattr(hid_replay, "BleakClient", lambda addr: dummy)
+
+    asyncio.run(hid_replay.replay("AA:BB", "1234", pfile))
+
+    assert dummy.writes == [
+        ("1234", bytes.fromhex("01ff")),
+        ("1234", bytes.fromhex("02aa")),
+    ]


### PR DESCRIPTION
## Summary
- implement `active.hid_replay` for replaying HID packets via Bleak
- add `hid-replay` command to the Typer CLI
- provide test coverage for the HID replay functionality
- expand proposal document with future HID injection and protocol radar ideas

## Testing
- `ruff check --select ALL --fix active/hid_replay.py cli/main.py tests/test_hid_replay.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e70db103c832b9fa6f2f6f0560943

## Summary by Sourcery

Implement HID replay capability by adding a new active.hid_replay module, wiring it into the CLI, covering it with tests, and updating the project proposals.

New Features:
- Add HID replay module to replay HID notifications over BLE
- Integrate new HID replay functionality into the Typer CLI with a `hid-replay` command

Documentation:
- Expand proposal document with future HID injection support and protocol radar ideas

Tests:
- Add end-to-end test for HID replay functionality using a dummy Bleak client