### PR TITLE
Add radio backend plugin system with BlueZ

### DIFF
--- a/ble_scanner/__init__.py
+++ b/ble_scanner/__init__.py
@@ -1,0 +1,13 @@
+"""BLE Scanner core package."""
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ble_scanner/plugins/__init__.py
+++ b/ble_scanner/plugins/__init__.py
@@ -1,0 +1,70 @@
+"""Radio backend plugin architecture."""
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import AsyncIterator, Dict, Optional, Set, Type
+
+__all__ = [
+    "RawPacket",
+    "RadioBackend",
+    "BlueZBackend",
+    "get_backend",
+]
+
+
+@dataclass
+class RawPacket:
+    """Minimal raw packet representation."""
+
+    timestamp: datetime
+    phy: str
+    channel: Optional[int]
+    rssi: Optional[int]
+    address: Optional[str] = None
+    access_addr: Optional[str] = None
+    handle: Optional[int] = None
+    pdu_type: Optional[str] = None
+    payload: bytes = b""
+
+
+class RadioBackend(ABC):
+    """Abstract base class for radio backends."""
+
+    name: str
+    capabilities: Set[str] = set()
+
+    @abstractmethod
+    async def scan(self) -> AsyncIterator[RawPacket]:
+        """Yield raw packets from the radio."""
+
+
+def get_backend(name: str) -> Optional[Type[RadioBackend]]:
+    """Return backend class by name."""
+
+    modules: Dict[str, str] = {
+        "bluez": "ble_scanner.plugins.bluez",
+    }
+    module_name = modules.get(name.lower())
+    if module_name is None:
+        return None
+    module = importlib.import_module(module_name)
+    return getattr(module, "Backend")
+
+
+from .bluez import Backend as BlueZBackend

--- a/ble_scanner/plugins/bluez.py
+++ b/ble_scanner/plugins/bluez.py
@@ -1,0 +1,48 @@
+"""BlueZ radio backend using Bleak."""
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import AsyncIterator
+
+from bleak import BleakScanner
+
+from . import RadioBackend, RawPacket
+
+
+class Backend(RadioBackend):
+    """BlueZ implementation of :class:`RadioBackend`."""
+
+    name = "bluez"
+    capabilities = {"advertising"}
+
+    def __init__(self, timeout: int = 5) -> None:
+        self.timeout = timeout
+
+    async def scan(self) -> AsyncIterator[RawPacket]:
+        while True:
+            devices = await BleakScanner.discover(timeout=self.timeout)
+            now = datetime.now()
+            for dev in devices:
+                yield RawPacket(
+                    timestamp=now,
+                    phy="LE1M",
+                    channel=None,
+                    rssi=dev.rssi,
+                    address=dev.address,
+                    payload=b"",
+                )
+            await asyncio.sleep(0)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,70 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ble_scanner.plugins import get_backend
+from core.scanner import EVENT_BUS, run_radio_backend
+
+
+class DummyDevice(SimpleNamespace):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_get_backend():
+    backend_cls = get_backend("bluez")
+    assert backend_cls is not None
+
+
+@pytest.mark.asyncio
+async def test_bluez_backend_scan(monkeypatch):
+    backend_cls = get_backend("bluez")
+    assert backend_cls is not None
+
+    async def fake_discover(timeout=5):
+        return [DummyDevice(address="AA:BB", rssi=-10)]
+
+    with patch("ble_scanner.plugins.bluez.BleakScanner.discover", fake_discover):
+        backend = backend_cls(timeout=0)
+        gen = backend.scan()
+        packet = await gen.__anext__()
+        assert packet.address == "AA:BB"
+        await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_run_radio_backend(monkeypatch):
+    backend_cls = get_backend("bluez")
+    assert backend_cls is not None
+
+    async def fake_discover(timeout=5):
+        return [DummyDevice(address="CC:DD", rssi=-20)]
+
+    with patch("ble_scanner.plugins.bluez.BleakScanner.discover", fake_discover):
+        backend = backend_cls(timeout=0)
+        stop = asyncio.Event()
+
+        async def runner():
+            with patch("core.scanner.update_device", return_value=None):
+                task = asyncio.create_task(run_radio_backend(backend, stop_event=stop))
+                event = await asyncio.wait_for(EVENT_BUS.get(), timeout=0.2)
+                stop.set()
+                await task
+                return event
+
+        event = await runner()
+        assert event["address"] == "CC:DD"


### PR DESCRIPTION
## Summary
- implement plugin API in `ble_scanner.plugins`
- add `BlueZ` backend using Bleak
- support selecting backend from CLI
- provide helper `run_radio_backend`
- tests for backend and runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e728685dc832b9f68e8d69f669470

## Summary by Sourcery

Add a pluggable radio backend system with a BlueZ implementation, allowing users to select and run different BLE scanning backends via the CLI

New Features:
- Implement radio backend plugin API in ble_scanner.plugins
- Add BlueZ radio backend plugin using Bleak
- Enable selecting radio backend via CLI '--backend' option
- Introduce run_radio_backend helper to run external backends

Enhancements:
- Integrate plugin-based backends into the CLI scan command

Tests:
- Add tests for plugin discovery and BlueZ backend scanning
- Add tests for run_radio_backend execution and event emission