### PR TITLE
Lazy load BLE plugins

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -24,6 +24,29 @@ class DummyDevice(SimpleNamespace):
     pass
 
 
+def test_get_backend_imports_module(monkeypatch):
+    class DummyBackend:
+        pass
+
+    dummy_module = SimpleNamespace(Backend=DummyBackend)
+
+    called = {}
+
+    def fake_import(name):
+        called["name"] = name
+        return dummy_module
+
+    monkeypatch.setattr(
+        "ble_scanner.plugins.importlib.import_module", fake_import
+    )
+
+    backend_cls = get_backend("bluez")
+    assert backend_cls is DummyBackend
+    assert called["name"] == "ble_scanner.plugins.bluez"
+    from ble_scanner import plugins as plugins_mod
+    plugins_mod._BACKENDS.clear()
+
+
 @pytest.mark.asyncio
 async def test_get_backend():
     backend_cls = get_backend("bluez")


### PR DESCRIPTION
## Summary
- avoid importing backend modules until needed
- cache backend classes once loaded
- test lazy loading via patched importlib

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e75716548832b8944ae5b79fe83ba