### PR TITLE
Add test dep install script and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - name: Install
-        run: |
-          pip install -r requirements.txt
-          pip install pytest
+      - name: Install test dependencies
+        run: scripts/install_test_deps.sh
       - name: Test
         run: pytest -q

--- a/feature_proposals.md
+++ b/feature_proposals.md
@@ -1,0 +1,9 @@
+# Additional Feature Proposals
+
+The following ideas would further enhance the BLE Scanner Suite:
+
+- **Remote firmware updates** – push firmware images to connected BLE devices directly from the dashboard.
+- **Custom alert rules** – allow users to create alert conditions using a simple rule editor.
+- **Power usage tracking** – estimate energy consumption for long‑term device monitoring.
+- **Auto‑generated reports** – schedule summary reports of detected devices and activity trends.
+- **Geo‑fencing** – trigger notifications when devices appear outside user‑defined zones.

--- a/scripts/install_test_deps.sh
+++ b/scripts/install_test_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Install runtime dependencies
+pip install -r requirements.txt
+
+# Install test-specific dependencies
+pip install pytest


### PR DESCRIPTION
## Summary
- add a script to install test dependencies
- call the script from CI
- document additional feature ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7713f958832bb8caddd8566ec9dd

## Summary by Sourcery

Add a script to install runtime and test dependencies, integrate it into the CI workflow, and include a document of additional feature proposals.

CI:
- Invoke scripts/install_test_deps.sh in the CI workflow to install dependencies

Documentation:
- Create feature_proposals.md outlining additional BLE Scanner Suite feature ideas

Tests:
- Add scripts/install_test_deps.sh to install runtime and pytest dependencies