### PR TITLE
Add Ubertooth, nRF and BtleJack radio backends

### DIFF
--- a/ble_scanner/plugins/__init__.py
+++ b/ble_scanner/plugins/__init__.py
@@ -55,6 +55,9 @@ class RadioBackend(ABC):
 
 _MODULES: Dict[str, str] = {
     "bluez": "ble_scanner.plugins.bluez",
+    "ubertooth": "ble_scanner.plugins.ubertooth",
+    "nrf": "ble_scanner.plugins.nrf",
+    "btlejack": "ble_scanner.plugins.btlejack",
 }
 
 _BACKENDS: Dict[str, Type[RadioBackend]] = {}
@@ -74,5 +77,3 @@ def get_backend(name: str) -> Optional[Type[RadioBackend]]:
     backend = getattr(module, "Backend")
     _BACKENDS[key] = backend
     return backend
-
-

--- a/ble_scanner/plugins/btlejack.py
+++ b/ble_scanner/plugins/btlejack.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import AsyncIterator
+
+from . import RadioBackend, RawPacket
+
+
+class Backend(RadioBackend):
+    """BtleJack implementation of :class:`RadioBackend`."""
+
+    name = "btlejack"
+    capabilities = {"advertising"}
+
+    def __init__(self, command: str = "btlejack") -> None:
+        self.command = command
+
+    async def scan(self) -> AsyncIterator[RawPacket]:
+        proc = await asyncio.create_subprocess_exec(
+            self.command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        assert proc.stdout is not None
+        try:
+            async for raw in proc.stdout:
+                line = raw.decode().strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                addr, rssi = parts[0], int(parts[-1])
+                yield RawPacket(
+                    timestamp=datetime.now(),
+                    phy="LE1M",
+                    channel=None,
+                    rssi=rssi,
+                    address=addr,
+                    payload=b"",
+                )
+                await asyncio.sleep(0)
+        finally:
+            proc.kill()
+            await proc.wait()

--- a/ble_scanner/plugins/nrf.py
+++ b/ble_scanner/plugins/nrf.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import AsyncIterator
+
+from . import RadioBackend, RawPacket
+
+
+class Backend(RadioBackend):
+    """nRF Sniffer implementation of :class:`RadioBackend`."""
+
+    name = "nrf"
+    capabilities = {"advertising"}
+
+    def __init__(self, command: str = "nrf-sniffer") -> None:
+        self.command = command
+
+    async def scan(self) -> AsyncIterator[RawPacket]:
+        proc = await asyncio.create_subprocess_exec(
+            self.command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        assert proc.stdout is not None
+        try:
+            async for raw in proc.stdout:
+                line = raw.decode().strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                addr, rssi = parts[0], int(parts[-1])
+                yield RawPacket(
+                    timestamp=datetime.now(),
+                    phy="LE1M",
+                    channel=None,
+                    rssi=rssi,
+                    address=addr,
+                    payload=b"",
+                )
+                await asyncio.sleep(0)
+        finally:
+            proc.kill()
+            await proc.wait()

--- a/ble_scanner/plugins/ubertooth.py
+++ b/ble_scanner/plugins/ubertooth.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import AsyncIterator
+
+from . import RadioBackend, RawPacket
+
+
+class Backend(RadioBackend):
+    """Ubertooth implementation of :class:`RadioBackend`."""
+
+    name = "ubertooth"
+    capabilities = {"advertising"}
+
+    def __init__(self, command: str = "ubertooth-btle") -> None:
+        self.command = command
+
+    async def scan(self) -> AsyncIterator[RawPacket]:
+        proc = await asyncio.create_subprocess_exec(
+            self.command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        assert proc.stdout is not None
+        try:
+            async for raw in proc.stdout:
+                line = raw.decode().strip()
+                if not line:
+                    continue
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                addr, rssi = parts[0], int(parts[-1])
+                yield RawPacket(
+                    timestamp=datetime.now(),
+                    phy="LE1M",
+                    channel=None,
+                    rssi=rssi,
+                    address=addr,
+                    payload=b"",
+                )
+                await asyncio.sleep(0)
+        finally:
+            proc.kill()
+            await proc.wait()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -36,14 +36,13 @@ def test_get_backend_imports_module(monkeypatch):
         called["name"] = name
         return dummy_module
 
-    monkeypatch.setattr(
-        "ble_scanner.plugins.importlib.import_module", fake_import
-    )
+    monkeypatch.setattr("ble_scanner.plugins.importlib.import_module", fake_import)
 
     backend_cls = get_backend("bluez")
     assert backend_cls is DummyBackend
     assert called["name"] == "ble_scanner.plugins.bluez"
     from ble_scanner import plugins as plugins_mod
+
     plugins_mod._BACKENDS.clear()
 
 
@@ -91,3 +90,80 @@ async def test_run_radio_backend(monkeypatch):
 
         event = await runner()
         assert event["address"] == "CC:DD"
+
+
+class DummyStream:
+    def __init__(self, lines: list[str]):
+        self._lines = [line.encode() for line in lines]
+
+    def __aiter__(self):
+        self._iter = iter(self._lines)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class DummyProc:
+    def __init__(self, lines: list[str]):
+        self.stdout = DummyStream(lines)
+
+    def kill(self) -> None:  # pragma: no cover - not triggered
+        pass
+
+    async def wait(self) -> None:  # pragma: no cover - not triggered
+        pass
+
+
+@pytest.mark.asyncio
+async def test_ubertooth_backend_scan(monkeypatch):
+    backend_cls = get_backend("ubertooth")
+    assert backend_cls is not None
+
+    async def fake_exec(*args, **kwargs):
+        return DummyProc(["AA:BB -30"])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    backend = backend_cls()
+    gen = backend.scan()
+    packet = await gen.__anext__()
+    assert packet.address == "AA:BB"
+    assert packet.rssi == -30
+    await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_nrf_backend_scan(monkeypatch):
+    backend_cls = get_backend("nrf")
+    assert backend_cls is not None
+
+    async def fake_exec(*args, **kwargs):
+        return DummyProc(["CC:DD -40"])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    backend = backend_cls()
+    gen = backend.scan()
+    packet = await gen.__anext__()
+    assert packet.address == "CC:DD"
+    assert packet.rssi == -40
+    await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_btlejack_backend_scan(monkeypatch):
+    backend_cls = get_backend("btlejack")
+    assert backend_cls is not None
+
+    async def fake_exec(*args, **kwargs):
+        return DummyProc(["EE:FF -50"])
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    backend = backend_cls()
+    gen = backend.scan()
+    packet = await gen.__anext__()
+    assert packet.address == "EE:FF"
+    assert packet.rssi == -50
+    await gen.aclose()


### PR DESCRIPTION
## Summary
- implement `ubertooth`, `nrf` and `btlejack` radio backends
- register backends in plugin loader
- extend plugin tests for the new backends

## Testing
- `ruff check .` *(fails: F811, F401, F821, etc.)*
- `black --check .` *(fails: would reformat several files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e77123f80832bb2ba8c3762c161bc